### PR TITLE
[MONDRIAN-1581] Fixing datatypes which were incorrectly marshalled in XM...

### DIFF
--- a/src/main/java/mondrian/xmla/XmlaHandler.java
+++ b/src/main/java/mondrian/xmla/XmlaHandler.java
@@ -5,7 +5,7 @@
 // You must accept the terms of that agreement to use this software.
 //
 // Copyright (C) 2003-2005 Julian Hyde
-// Copyright (C) 2005-2012 Pentaho
+// Copyright (C) 2005-2013 Pentaho
 // All Rights Reserved.
 */
 package mondrian.xmla;
@@ -184,6 +184,8 @@ public class XmlaHandler {
     // xsd:double: IEEE 64-bit floating-point
     public static final String XSD_DOUBLE = "xsd:double";
 
+    public static final String XSD_FLOAT = "xsd:float";
+
     // xsd:decimal: Decimal numbers (BigDecimal)
     public static final String XSD_DECIMAL = "xsd:decimal";
 
@@ -271,12 +273,12 @@ public class XmlaHandler {
                         this.isDecimal = false;
 
                     } else if (inputValue instanceof Byte) {
-                        this.valueType = valueTypeHint;
+                        this.valueType = XSD_BYTE;
                         this.value = inputValue;
                         this.isDecimal = false;
 
                     } else if (inputValue instanceof Short) {
-                        this.valueType = valueTypeHint;
+                        this.valueType = XSD_SHORT;
                         this.value = inputValue;
                         this.isDecimal = false;
 
@@ -311,7 +313,7 @@ public class XmlaHandler {
 
                         } else {
                             // It can not be converted to a long.
-                            this.valueType = XSD_DOUBLE;
+                            this.valueType = XSD_FLOAT;
                             this.value = inputValue;
                             this.isDecimal = true;
                         }
@@ -399,7 +401,7 @@ public class XmlaHandler {
 
                     } else if (inputValue instanceof Float) {
                         this.value = inputValue;
-                        this.valueType = valueTypeHint;
+                        this.valueType = XSD_FLOAT;
                         this.isDecimal = true;
 
                     } else if (inputValue instanceof BigDecimal) {
@@ -473,13 +475,13 @@ public class XmlaHandler {
 
                 } else if (inputValue instanceof Byte) {
                     Byte b = (Byte) inputValue;
-                    this.valueType = XSD_INT;
+                    this.valueType = XSD_BYTE;
                     this.value = b.intValue();
                     this.isDecimal = false;
 
                 } else if (inputValue instanceof Short) {
                     Short s = (Short) inputValue;
-                    this.valueType = XSD_INT;
+                    this.valueType = XSD_SHORT;
                     this.value = s.intValue();
                     this.isDecimal = false;
 
@@ -503,7 +505,7 @@ public class XmlaHandler {
                     }
 
                 } else if (inputValue instanceof Float) {
-                    this.valueType = XSD_DOUBLE;
+                    this.valueType = XSD_FLOAT;
                     this.value = inputValue;
                     this.isDecimal = true;
 
@@ -542,6 +544,10 @@ public class XmlaHandler {
                     this.valueType = XSD_LONG;
                     this.isDecimal = false;
 
+                } else if (inputValue instanceof Boolean) {
+                    this.value = inputValue;
+                    this.valueType = XSD_BOOLEAN;
+                    this.isDecimal = false;
                 } else {
                     // Who knows what we are dealing with,
                     // hope for the best?!?
@@ -2024,7 +2030,7 @@ public class XmlaHandler {
                 + "."
                 + Util.quoteMdxIdentifier(longProp.getName()));
             if (longProp == prop) {
-                //Adding type attribute to the optional properties
+                // Adding type attribute to the optional properties
                 values.add("type");
                 values.add(getXsdType(longProp));
             }
@@ -2739,9 +2745,9 @@ public class XmlaHandler {
                 if (axis >= 2) {
                     iterate(writer, axis - 1, ho);
                 } else {
-                    writer.startElement("row");//abrimos la fila
-                    pos[axis] = i; //coordenadas: fila i
-                    pos[0] = 0; //coordenadas (0,i): columna 0
+                    writer.startElement("row");// abrimos la fila
+                    pos[axis] = i; // coordenadas: fila i
+                    pos[0] = 0; // coordenadas (0,i): columna 0
                     for (ColumnHandler columnHandler : columnHandlers) {
                         if (columnHandler instanceof MemberColumnHandler) {
                             columnHandler.write(writer, null, this.members);
@@ -2751,7 +2757,7 @@ public class XmlaHandler {
                             pos[0]++;// next col.
                         }
                     }
-                    writer.endElement();//cerramos la fila
+                    writer.endElement();// cerramos la fila
                 }
             }
         }


### PR DESCRIPTION
...LA responses:  Boolean, Short, Byte, Float (were formerly treated as xsd:string, xsd:int, xsd:int, and xsd:double, respectively)

merged from 534768
