### PR TITLE
fix olap4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.olap4j</groupId>
       <artifactId>olap4j</artifactId>
-      <version>1.0.1-SNAPSHOT</version>
+      <version>1.2.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>


### PR DESCRIPTION
we need to keep the olap4j versions in sync

i cant build projects that use mondrian 4 anymore because xmlaserver references olap4j-xmla 1.0.1 - which doesn't exist anymore in a repo
